### PR TITLE
Adjust config file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@tailwindcss/typography": "^0.5.14",
         "autoprefixer": "^10.4.20",
         "babel-plugin-istanbul": "^7.0.0",
+        "dotenv": "^16.4.7",
         "postcss": "^8.4.41",
         "start-server-and-test": "^2.0.8",
         "tailwindcss": "3.4.10"
@@ -2075,11 +2076,10 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@tailwindcss/typography": "^0.5.14",
     "autoprefixer": "^10.4.20",
     "babel-plugin-istanbul": "^7.0.0",
+    "dotenv": "^16.4.7",
     "postcss": "^8.4.41",
     "start-server-and-test": "^2.0.8",
     "tailwindcss": "3.4.10"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,11 @@
 import { currentsReporter } from "@currents/playwright";
 import { devices, PlaywrightTestConfig } from "@playwright/test";
+import * as dotenv from "dotenv";
+dotenv.config();
 
 const baseURL = "http://localhost:3000";
+
+console.log("DATA::", process.env.CURRENTS_RECORD_KEY);
 
 const config: PlaywrightTestConfig = {
   timeout: 10 * 1000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,13 +1,23 @@
-import { currentsReporter } from "@currents/playwright";
-import { devices, PlaywrightTestConfig } from "@playwright/test";
+import {
+  CurrentsFixtures,
+  currentsReporter,
+  CurrentsWorkerFixtures,
+} from "@currents/playwright";
+import { defineConfig, devices } from "@playwright/test";
 import * as dotenv from "dotenv";
 dotenv.config();
 
 const baseURL = "http://localhost:3000";
 
-console.log("DATA::", process.env.CURRENTS_RECORD_KEY);
+const currentsConfig = {
+  recordKey: process.env.CURRENTS_RECORD_KEY ?? "your-record-key",
+  projectId: process.env.CURRENTS_PROJECT_ID ?? "your-project-id",
+  coverage: {
+    projects: true,
+  },
+};
 
-const config: PlaywrightTestConfig = {
+const config = defineConfig<CurrentsFixtures, CurrentsWorkerFixtures>({
   timeout: 10 * 1000,
 
   use: {
@@ -16,17 +26,10 @@ const config: PlaywrightTestConfig = {
     screenshot: "off",
     video: "off",
     trace: "off",
+    currentsConfigOptions: currentsConfig,
   },
 
-  reporter: [
-    currentsReporter({
-      recordKey: process.env.CURRENTS_RECORD_KEY ?? "your-record-key",
-      projectId: process.env.CURRENTS_PROJECT_ID ?? "your-project-id",
-      coverage: {
-        projects: true,
-      },
-    }),
-  ],
+  reporter: [currentsReporter(currentsConfig)],
   projects: [
     {
       name: "chromium",
@@ -52,6 +55,6 @@ const config: PlaywrightTestConfig = {
   ],
 
   outputDir: "test-results/",
-};
+});
 
 export default config;


### PR DESCRIPTION
The config file in the repository is not set according to the [documentation](https://docs.currents.dev/guides/coverage/code-coverage-for-playwright#setting-up-the-currents-reporter). This is causing that when using `npm run test` to not extract the Currents config record key and project id. (It will only work if adding this if set in an .env file.

The .env file leads to the other issue which is that the repository does not configure dotenv for reading env variables. So this PR also add dotenv for fixing it.

Error showed when trying to execute any test command in the repository.
```
  TypeError: Cannot read properties of null (reading 'coverage')

      at ei (/Users/miguelangarano/Documents/GitHub/currents-playwright-coverage-example/node_modules/@currents/playwright/dist/index.js:18:2325)
      at Object.ts (/Users/miguelangarano/Documents/GitHub/currents-playwright-coverage-example/node_modules/@currents/playwright/dist/index.js:18:3266)
```